### PR TITLE
Use print() function in both Python 2 and Python 3

### DIFF
--- a/stomp_main.py
+++ b/stomp_main.py
@@ -1,23 +1,24 @@
 #!/usr/bin/env python
-# 
+#
 # Copyright 2018 IBM
-# 
+#
 # This is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation; either version 3, or (at your option)
 # any later version.
-# 
+#
 # This software is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU General Public License
 # along with this software; see the file COPYING.  If not, write to
 # the Free Software Foundation, Inc., 51 Franklin Street,
 # Boston, MA 02110-1301, USA.
-# 
+#
 
+from __future__ import print_function
 import sys, getopt
 import importlib
 import json
@@ -26,7 +27,7 @@ from stomp import STOMP
 
 
 def usage_and_exit(exit_code):
-    print 'usage: stomp_main.py [--help] [--debug] [--conf-file=<json_config_file>] [--conf-json=<json_string>] [--arrival-trace=<string>] [--input-trace=<string>] [--generate-trace=<string>] [--pre-gen-arrivals]'
+    print('usage: stomp_main.py [--help] [--debug] [--conf-file=<json_config_file>] [--conf-json=<json_string>] [--arrival-trace=<string>] [--input-trace=<string>] [--generate-trace=<string>] [--pre-gen-arrivals]')
     sys.exit(exit_code)
 
 
@@ -79,7 +80,7 @@ def main(argv):
         # We update configuration parameters with JSON
         # values received through the command line
         update(stomp_params, conf_json)
-    
+
     # Dinamically import the scheduling policy class
     sched_policy_module = importlib.import_module(stomp_params['simulation']['sched_policy_module'])
 
@@ -88,7 +89,7 @@ def main(argv):
 
     if (pre_gen):
         stomp_params['general']['pre_gen_arrivals'] = True
-        
+
     #print('Setting input_arr_tr file to %s and output_tr_file to %s\n' % (input_trace_file, output_trace_file))
     stomp_params['general']['input_trace_file'] = input_trace_file
     stomp_params['general']['output_trace_file'] = output_trace_file

--- a/utils/run_all.py
+++ b/utils/run_all.py
@@ -28,6 +28,7 @@ import os
 import subprocess
 import json
 import time
+import shutil
 import sys
 import getopt
 from sys import stdout

--- a/utils/run_all_2.py
+++ b/utils/run_all_2.py
@@ -34,6 +34,7 @@ import os
 import subprocess
 import json
 import time
+import shutil
 import sys
 import getopt
 from sys import stdout


### PR DESCRIPTION
Legacy __print__ statements are _syntax errors_ in Python 3 while __print()__ function works as expected in both Python 2 and Python 3.

[flake8](http://flake8.pycqa.org) testing of https://github.com/IBM/stomp on Python 3.7.1

$ __flake8 . --count --select=E9,F63,F72,F82 --show-source --statistics__
```
./stomp_main.py:29:213: E999 SyntaxError: invalid syntax
    print 'usage: stomp_main.py [--help] [--debug] [--conf-file=<json_config_file>] [--conf-json=<json_string>] [--arrival-trace=<string>] [--input-trace=<string>] [--generate-trace=<string>] [--pre-gen-arrivals]'
                                                                                                                                                                                                                    ^
./utils/run_all_2.py:114:9: F821 undefined name 'shutil'
        shutil.rmtree(sim_dir)
        ^
./utils/run_all.py:98:9: F821 undefined name 'shutil'
        shutil.rmtree(sim_dir)
        ^
1     E999 SyntaxError: invalid syntax
2     F821 undefined name 'shutil'
3
```
__E901,E999,F821,F822,F823__ are the "_showstopper_" [flake8](http://flake8.pycqa.org) issues that can halt the runtime with a SyntaxError, NameError, etc. These 5 are different from most other flake8 issues which are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree
